### PR TITLE
Update UI to have tab title reflect Report title per issue TRAM-24

### DIFF
--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -62,7 +62,7 @@ class WebAPI:
         attack_uids = await self.dao.get('attack_uids')
         original_html = await self.dao.get('original_html', dict(report_uid=report_needed[0]['uid']))
         final_html = await self.web_svc.build_final_html(original_html, sentences)
-        return dict(file=request.match_info.get('file'), sentences=sentences, attack_uids=attack_uids, original_html=original_html, final_html=final_html)
+        return dict(file=request.match_info.get('file'), title=report_needed[0]['title'], sentences=sentences, attack_uids=attack_uids, original_html=original_html, final_html=final_html)
 
     async def pdf_export(self, request):
         """

--- a/webapp/html/base.html
+++ b/webapp/html/base.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <link rel='shortcut icon' href='/theme/images/favicon-blue-m.ico' type='image/x-icon'>
 
-        <title>MITRE ATT&CK&trade; - TRAM</title>
+        <title>{% block title %}MITRE ATT&CK&trade; - TRAM{% endblock %}</title>
         <link rel='stylesheet' href='/theme/style/bootstrap.min.css'/>
         <link rel='stylesheet' href='/theme/style/bootstrap-glyphicon.min.css'/>
         <link rel='stylesheet' href='/theme/style/bootstrap-select.css'/>

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}{{ title }}{% endblock %}
 {% block content %}
 
 <style>


### PR DESCRIPTION
Update UI to have tab title reflect Report title.
When you select the Analyze button for a report, the edit page will now have the report title in the tab title of the page.