### PR TITLE
Images clickable and can add techniques; TRAM-15. 

### DIFF
--- a/conf/schema.sql
+++ b/conf/schema.sql
@@ -73,13 +73,19 @@ CREATE TABLE if not exists true_negatives (
     );
 
 CREATE TABLE if not exists original_html (
-    uid INTEGER,
+    uid INTEGER PRIMARY KEY AUTOINCREMENT,
     report_uid INTEGER,
     text TEXT,
     tag TEXT,
     found_status TEXT
     );
 
+CREATE TABLE if not exists image_positives (
+    uid VARCHAR(60),
+    sentence_id integer,
+    true_positive TEXT,
+    FOREIGN KEY(uid) REFERENCES attack_uids(uid)
+    );
 
 
 --INSERT INTO regex_patterns (attack_uid, regex_pattern) values ("attack-pattern--01df3350-ce05-4bdf-bdf8-0a919a66d4a8", "sometext.*moretext")

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -38,13 +38,16 @@ class WebAPI:
                 false_positive=lambda d: self.rest_svc.false_positive(criteria=d),
                 true_positive=lambda d: self.rest_svc.true_positive(criteria=d),
                 false_negative=lambda d: self.rest_svc.false_negative(criteria=d),
+                image_positive=lambda d: self.rest_svc.image_positive(criteria=d),
                 set_status=lambda d: self.rest_svc.set_status(criteria=d),
                 insert_report=lambda d: self.rest_svc.insert_report(criteria=d),
                 remove_sentences=lambda d: self.rest_svc.remove_sentences(criteria=d),
                 delete_report=lambda d: self.rest_svc.delete_report(criteria=d),
                 sentence_context=lambda d: self.rest_svc.sentence_context(criteria=d),
                 confirmed_sentences=lambda d: self.rest_svc.confirmed_sentences(criteria=d),
-                missing_technique=lambda d: self.rest_svc.missing_technique(criteria=d)
+                missing_technique=lambda d: self.rest_svc.missing_technique(criteria=d),
+                image_context=lambda d: self.rest_svc.image_context(criteria=d),
+                confirmed_images=lambda d: self.rest_svc.confirmed_images(criteria=d)
 
             ))
         output = await options[request.method][index](data)

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -57,6 +57,24 @@ class RestService:
             tmp.append(name[0])
         return tmp
 
+    async def image_context(self, criteria=None):
+        return []
+
+    async def confirmed_images(self, criteria=None):
+        tmp = []
+        techniques = await self.dao.get('image_positives', dict(sentence_id = criteria['sentence_id']))
+        for tech in techniques:
+            name = await self.dao.get('attack_uids', dict(uid=tech['uid']))
+            tmp.append(name[0])
+        return tmp
+    
+    async def image_positive(self, criteria=None):
+        sentence_dict = await self.dao.get('report_sentences', dict(uid=criteria['sentence_id']))
+        sentence_to_insert = await self.web_svc.remove_html_markup_and_found(sentence_dict[0]['text'])
+        await self.dao.insert('image_positives', dict(sentence_id=sentence_dict[0]['uid'], uid=criteria['attack_uid'],
+                                                     true_positive=sentence_to_insert))
+        return dict(status='inserted')
+
     async def true_positive(self, criteria=None):
         sentence_dict = await self.dao.get('report_sentences', dict(uid=criteria['sentence_id']))
         sentence_to_insert = await self.web_svc.remove_html_markup_and_found(sentence_dict[0]['text'])

--- a/service/web_svc.py
+++ b/service/web_svc.py
@@ -51,6 +51,7 @@ class WebService:
 
     async def build_final_html(self, original_html, sentences):
         final_html = []
+        
         for element in original_html:
             if element['tag'] == 'img':
                 final_element = await self._build_final_image_dict(element)

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -36,7 +36,7 @@
     <div class="col reportSentencesDiv">
         {% for elmt in final_html %}
             {% if elmt.tag == 'img' %}
-                <img src="{{elmt.text}}" class="normalImage">
+                <img src="{{elmt.text}}" class="normalImage" onclick="imageContext({{elmt.uid}})">
             {% elif elmt.found_status == 'true' %}
                 <a class="bg-warning" id="elmt{{elmt.uid}}" onclick="sentenceContext({{elmt.uid}})">{{elmt.text}}</a>
             {% else %}

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -2,7 +2,6 @@ var sentence_id = 0
 var image_clicked = false;
 
 function restRequest(type, data, callback) {
-  console.log(data)
     $.ajax({
        url: '/rest',
        type: type,
@@ -96,7 +95,6 @@ function savedAlert(){
  }
 
 function imageContext(data, attack_uid) {
-  console.log("in image context", data)
   image_clicked = true;
   restRequest('POST', {'index':'image_context', 'uid':data, 'attack_uid':attack_uid}, updateImageContext);
   restRequest('POST', {'index':'confirmed_images', 'sentence_id': data}, updateConfirmedContext);
@@ -106,10 +104,6 @@ function imageContext(data, attack_uid) {
 function updateImageContext(data) {
   $("#tableSentenceInfo tr").remove()
 }
-
-// function updateConfirmedImgContext(data) {
-//   console.log(data)
-// }
 
 function sentenceContext(data, attack_uid){
     image_clicked = false;
@@ -122,7 +116,7 @@ function updateSentenceContext(data){
     $("#tableSentenceInfo tr").remove()
     $.each(data, function(index, op){
         td1 = "<td><a href=https://attack.mitre.org/techniques/" + op.attack_tid + " target=_blank>" + op.attack_technique_name + "</a></td>"
-        td2 = `<td><button class='btn btn-success' onclick='true_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Accepto</button></td>`
+        td2 = `<td><button class='btn btn-success' onclick='true_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Accept</button></td>`
         td3 = `<td><button class='btn btn-danger' onclick='false_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Reject</button></td>`
         tmp = `<tr id="sentence-tid${op.attack_uid.substr(op.attack_uid.length - 4)}">${td1}${td2}${td3}</tr>`
         $("#tableSentenceInfo").find('tbody').append(tmp);
@@ -163,14 +157,10 @@ $(window).resize(function() {
 
 function addMissingTechnique(){
     uid = $("#missingTechniqueSelect :selected").val();
-    console.log(uid)
-    console.log("button pressed")
     if(image_clicked) {
-      console.log("Image clicked")
       restRequest('POST', {'index':'image_positive', 'sentence_id': sentence_id, 'attack_uid':uid}, savedAlert);
       imageContext(sentence_id, uid)
     } else {
-      console.log("Sentence clicked!")
       restRequest('POST', {'index':'true_positive', 'sentence_id': sentence_id, 'attack_uid':uid}, savedAlert);
       sentenceContext(sentence_id, uid)
     }

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -1,6 +1,8 @@
 var sentence_id = 0
+var image_clicked = false;
 
 function restRequest(type, data, callback) {
+  console.log(data)
     $.ajax({
        url: '/rest',
        type: type,
@@ -93,7 +95,24 @@ function savedAlert(){
     }
  }
 
+function imageContext(data, attack_uid) {
+  console.log("in image context", data)
+  image_clicked = true;
+  restRequest('POST', {'index':'image_context', 'uid':data, 'attack_uid':attack_uid}, updateImageContext);
+  restRequest('POST', {'index':'confirmed_images', 'sentence_id': data}, updateConfirmedContext);
+  sentence_id = data;
+}
+
+function updateImageContext(data) {
+  $("#tableSentenceInfo tr").remove()
+}
+
+// function updateConfirmedImgContext(data) {
+//   console.log(data)
+// }
+
 function sentenceContext(data, attack_uid){
+    image_clicked = false;
     restRequest('POST', {'index':'sentence_context', 'uid': data, 'attack_uid':attack_uid}, updateSentenceContext);
     restRequest('POST', {'index':'confirmed_sentences', 'sentence_id': data}, updateConfirmedContext);
     sentence_id = data;
@@ -103,7 +122,7 @@ function updateSentenceContext(data){
     $("#tableSentenceInfo tr").remove()
     $.each(data, function(index, op){
         td1 = "<td><a href=https://attack.mitre.org/techniques/" + op.attack_tid + " target=_blank>" + op.attack_technique_name + "</a></td>"
-        td2 = `<td><button class='btn btn-success' onclick='true_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Accept</button></td>`
+        td2 = `<td><button class='btn btn-success' onclick='true_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Accepto</button></td>`
         td3 = `<td><button class='btn btn-danger' onclick='false_positive(true_positive, ${op.uid}, \"${op.attack_uid}\")'>Reject</button></td>`
         tmp = `<tr id="sentence-tid${op.attack_uid.substr(op.attack_uid.length - 4)}">${td1}${td2}${td3}</tr>`
         $("#tableSentenceInfo").find('tbody').append(tmp);
@@ -144,7 +163,16 @@ $(window).resize(function() {
 
 function addMissingTechnique(){
     uid = $("#missingTechniqueSelect :selected").val();
-    restRequest('POST', {'index':'true_positive', 'sentence_id': sentence_id, 'attack_uid':uid}, savedAlert);
-    sentenceContext(sentence_id, uid)
+    console.log(uid)
+    console.log("button pressed")
+    if(image_clicked) {
+      console.log("Image clicked")
+      restRequest('POST', {'index':'image_positive', 'sentence_id': sentence_id, 'attack_uid':uid}, savedAlert);
+      imageContext(sentence_id, uid)
+    } else {
+      console.log("Sentence clicked!")
+      restRequest('POST', {'index':'true_positive', 'sentence_id': sentence_id, 'attack_uid':uid}, savedAlert);
+      sentenceContext(sentence_id, uid)
+    }
 }
 


### PR DESCRIPTION
Ignore previous commit b/c I didn't clean up code properly.

image_positives table similar purpose as true_positives table, just for images. Table will always be empty until user adds techniques to an image (b/c NLP does not touch). 

Rest API changes to handle UI updates after adding techniques to images.

imageContext method similar to sentenceContext. The purpose of this is to separate image user-declared techniques from NLP techniques on sentences. (In some cases an image has the same id as a sentence because they're in the same body in HTML).

Headers will be looked at. 