### PR TITLE
Updated trademarks to copyrights on site and in README - GH Issue #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TRAM v0.1
 
-Threat Report ATT&CK<sup>™</sup> Mapping (TRAM) is a tool to aid analyst in mapping finished reports to ATT&CK. TRAM is currently in its beta phase and is actively being developed.
+Threat Report ATT&CK<sup>®</sup> Mapping (TRAM) is a tool to aid analyst in mapping finished reports to ATT&CK. TRAM is currently in its beta phase and is actively being developed.
 
 ## Requirements
 - [python3](https://www.python.org/) (3.6.1+)
@@ -48,7 +48,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) to better understand what we're looking 
 
 ## Notice
 
-Copyright 2019 The MITRE Corporation
+Copyright ® 2019-2020 The MITRE Corporation
 
 Approved for Public Release; Distribution Unlimited. Case Number 19-3429.
 
@@ -58,6 +58,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-This project makes use of ATT&CK<sup>™</sup>
+This project makes use of ATT&CK<sup>®</sup>
 
 [ATT&CK Terms of Use](https://attack.mitre.org/resources/terms-of-use/)

--- a/webapp/html/base.html
+++ b/webapp/html/base.html
@@ -6,7 +6,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <link rel='shortcut icon' href='/theme/images/favicon-blue-m.ico' type='image/x-icon'>
 
-        <title>{% block title %}MITRE ATT&CK&trade; - TRAM{% endblock %}</title>
+        <title>{% block title %}MITRE ATT&CK&copy; - TRAM{% endblock %}</title>
         <link rel='stylesheet' href='/theme/style/bootstrap.min.css'/>
         <link rel='stylesheet' href='/theme/style/bootstrap-glyphicon.min.css'/>
         <link rel='stylesheet' href='/theme/style/bootstrap-select.css'/>
@@ -54,8 +54,10 @@
                     </div>
                     <div class="col-6 col-sm-6 text-center">
                         <p>
-                            Copyright © 2019, The MITRE Corporation. MITRE ATT&CK and ATT&CK are trademarks of The MITRE
-                            Corporation.
+                            Copyright © 2019-2020, The MITRE Corporation. 
+                        </p>
+                        <p>
+                            MITRE ATT&CK and ATT&CK are registered trademarks of The MITRE Corporation.
                         </p>
                         <div class="row">
                             <div class="col text-right">


### PR DESCRIPTION
Added spanning copyright, switched trademarks to copyrights, and added "registered" to footer.