### PR TITLE
Feature/multiple reports concurrent

### DIFF
--- a/service/ml_svc.py
+++ b/service/ml_svc.py
@@ -5,6 +5,7 @@ from sklearn.linear_model import LogisticRegression
 import os, pickle, random
 import nltk
 import logging
+import asyncio
 
 
 class MLService:
@@ -67,6 +68,7 @@ class MLService:
 
         df2 = pd.DataFrame({'text': cleaned_sentences})
         Xnew = cv.transform(df2['text']).toarray()
+        await asyncio.sleep(0.01)
         y_pred = logreg.predict(Xnew)
         df2['category'] = y_pred.tolist()
         return df2
@@ -95,6 +97,7 @@ class MLService:
             final_df = await self.analyze_document(cv, logreg, list_of_sentences)
             count = 0
             for vals in final_df['category']:
+                await asyncio.sleep(0.001)
                 if vals == True:
                     list_of_sentences[count]['ml_techniques_found'].append(i)
                 count += 1

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -12,9 +12,10 @@ class RestService:
         self.web_svc = web_svc
         self.ml_svc = ml_svc
         self.reg_svc = reg_svc
+        self.queue = asyncio.Queue()
         self.resources = []
-        self.monitor,child_conn = Pipe() # create pipe for server to comm with manager process
-        self.process_manager = Process(target=self.check_queue,args=(child_conn,)).start() # create manager process
+        #self.monitor,child_conn = Pipe() # create pipe for server to comm with manager process
+        #self.process_manager = Process(target=self.check_queue,args=(child_conn,)).start() # create manager process
 
     async def false_negative(self, criteria=None):
         sentence_dict = await self.dao.get('report_sentences', dict(uid=criteria['sentence_id']))
@@ -80,42 +81,58 @@ class RestService:
         #criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
         #                                                       current_status="needs_review"))
         criteria = dict(title=criteria['title'], url=criteria['url'],current_status="needs_review")
-        asyncio.create_task(self.check_queue(criteria)) # self.monitor.send(criteria) # send needed data to monitor process
+        await self.queue.put(criteria)
+        task = asyncio.create_task(self.check_queue()) # self.monitor.send(criteria) # send needed data to monitor process
         await asyncio.sleep(0.01)
     
 
-    async def check_queue(self,conn):
+    async def check_queue(self):
         '''
         description: runs as a child process that spawns worker processes via the multiprocessing library
         acts as manager for concurrent report analysis
         input: pipe connection
         output: nil
         '''
-        resources = [] # currently running processes
-        man_queue = asyncio.Queue() # manager queue for work to be done
-        max_workers = 1#cpu_count() # num workers based on num cpus
-        while(True):
-            
-            print(conn)
-            await man_queue.put(conn) # get data from pipe
-            print(man_queue)
-            while(not man_queue.empty()):
-                for proc in range(len(resources)):
-                    if(not resources[proc].is_alive()):
-                        del resources[proc] # if the process is finished, or dead, remove it from resources
-                if(len(resources) >= max_workers):
-                    await asyncio.sleep(1) # wait if resources are maxed
-                    print("Processing data, current processing workers: {}".format(resources))
-                else:
-                    to_process = await man_queue.get() # get next thing to do off queue
-                    resources.append(to_process)
-                    await self.start_analysis(to_process)
-                    #p = Process(target=self.analysis_wrapper,args=(to_process,)) # and analyze it
-                    #resources.append(p)
-                    #p.start()
+        for task in range(len(self.resources)):
+            if(self.resources[task].done()):
+                del self.resources[task]
+
+        max_tasks = 1
+        if(len(self.resources) >= max_tasks):
+            while(len(self.resources) >= max_tasks):
+                for task in range(len(self.resources)):
+                    if(self.resources[task].done()):
+                        del self.resources[task]
+                await asyncio.sleep(1) # figure out something to do here
+            criteria = await self.queue.get()
+            task = asyncio.create_task(self.start_analysis(criteria))
+            self.resources.append(task)
+        else:
+            criteria = await self.queue.get()
+            task = asyncio.create_task(self.start_analysis(criteria))
+            self.resources.append(task)
+
+        '''max_workers = 1#cpu_count() # num workers based on num cpus
+        print(conn)
+        await self.queue.put(conn) # get data from pipe
+        print(self.queue)
+        while(not self.queue.empty()):
+            for proc in range(len(self.resources)):
+                if(not self.resources[proc].is_alive()):
+                    del self.resources[proc] # if the process is finished, or dead, remove it from self.resources
+            if(len(self.resources) >= max_workers):
+                await asyncio.sleep(1) # wait if self.resources are maxed
+                print("Processing data, current processing workers: {}".format(self.resources))
+            else:
+                to_process = await self.queue.get() # get next thing to do off queue
+                self.resources.append(to_process)
+                await self.start_analysis(to_process)
+                #p = Process(target=self.analysis_wrapper,args=(to_process,)) # and analyze it
+                #self.resources.append(p)
+                #p.start()
             print("BEFORE!!!!")
             await asyncio.sleep(0.0001)
-            print("AFTER!!!!")
+            print("AFTER!!!!")'''
             
 
     def analysis_wrapper(self,criteria):
@@ -187,6 +204,7 @@ class RestService:
         for element in original_html:
             html_element = dict(report_uid=report_id, text=element['text'], tag=element['tag'], found_status="false")
             await self.dao.insert('original_html', html_element)
+        
 
     async def missing_technique(self, criteria=None):
         attack_uid = await self.dao.get('attack_uids', dict(tid=criteria['tid']))

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -77,9 +77,9 @@ class RestService:
         return dict(status='inserted', last=last)
 
     async def insert_report(self, criteria=None):
-        criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
-                                                               current_status="needs_review"))
-        
+        #criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
+        #                                                       current_status="needs_review"))
+        criteria = dict(title=criteria['title'], url=criteria['url'],current_status="needs_review")
         self.monitor.send(criteria) # send needed data to monitor process
     
     def check_queue(self,conn):
@@ -148,7 +148,6 @@ class RestService:
         original_html = await self.web_svc.map_all_html(criteria['url'])
 
         article = dict(title=criteria['title'], html_text=html_data)
-        report_id = criteria['id']
         list_of_legacy, list_of_techs = await self.data_svc.ml_reg_split(json_tech)
 
         true_negatives = await self.ml_svc.get_true_negs()
@@ -163,6 +162,9 @@ class RestService:
         # Merge ML and Reg hits
         analyzed_html = await self.ml_svc.combine_ml_reg(ml_analyzed_html, reg_analyzed_html)
 
+        criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
+                                                                            current_status="needs_review"))
+        report_id = criteria['id']
         for sentence in analyzed_html:
             if sentence['ml_techniques_found']:
                 await self.ml_svc.ml_techniques_found(report_id, sentence)

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -2,7 +2,7 @@ import json
 import asyncio
 import queue
 from concurrent.futures import ProcessPoolExecutor
-from multiprocessing import Process, Pool, Pipe
+from multiprocessing import Process, Pool, Pipe, cpu_count
 from time import sleep
 
 class RestService:
@@ -13,7 +13,6 @@ class RestService:
         self.web_svc = web_svc
         self.ml_svc = ml_svc
         self.reg_svc = reg_svc
-        self.queue = queue.SimpleQueue()
         self.resources = []
         self.monitor,child_conn = Pipe()
         self.process_manager = Process(target=self.check_queue,args=(child_conn,)).start()
@@ -78,63 +77,38 @@ class RestService:
                                                       false_positive=sentence_to_insert))
         return dict(status='inserted', last=last)
 
-
-
-    '''
-    For CPU bound processes run these
-    loop = asyncio.get_running_loop()
-
-    ## Options:
-
-    # 1. Run in the default loop's executor:
-    result = await loop.run_in_executor(
-        None, blocking_io)
-    print('default thread pool', result)
-
-    # 2. Run in a custom thread pool:
-    with concurrent.futures.ThreadPoolExecutor() as pool:
-        result = await loop.run_in_executor(
-            pool, blocking_io)
-        print('custom thread pool', result)
-
-    # 3. Run in a custom process pool:
-    with concurrent.futures.ProcessPoolExecutor() as pool:
-        result = await loop.run_in_executor(
-            pool, cpu_bound)
-        print('custom process pool', result)
-    '''
-
-
     async def insert_report(self, criteria=None):
         criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
                                                                current_status="needs_review"))
-        self.queue.put(criteria)
         #future = asyncio.Future()
         #loop = asyncio.get_event_loop()
         #loop.r
         #self.monitor.apply_async(self.check_queue())
-        self.monitor.send(self.queue.get())
-        print("DONE WITH MONITORING")
+        self.monitor.send(criteria)
         #p = Process(target=self.check_queue) 
         #p.start()
         #task = loop.run_in_executor(self.executor, self.check_queue)                                            
         # self.loop.create_task(self.start_analysis(criteria))
     
     def check_queue(self,conn):
-        #loop = asyncio.new_event_loop()
+        '''
+        description: runs as a child process that spawns worker processes via the multiprocessing library
+        acts as manager for concurrent report analysis
+        input: pipe connection
+        output: nil
+        '''
         resources = []
         man_queue = queue.SimpleQueue()
+        max_workers = cpu_count()
         while(True):
             man_queue.put(conn.recv())
             while(not man_queue.empty()):
-                print(man_queue.qsize())
                 for proc in range(len(resources)):
                     if(not resources[proc].is_alive()):
                         del resources[proc]
-
-                print("resource usage is {}".format(resources))
-                if(len(resources) > 0):
+                if(len(resources) > max_workers):
                     sleep(1)
+                    print("Processing data, current processing workers: {}".format(resources))
                 else:
                     to_process = man_queue.get()
                     p = Process(target=self.analysis_wrapper,args=(to_process,))
@@ -143,6 +117,11 @@ class RestService:
             
 
     def analysis_wrapper(self,criteria):
+        '''
+        description: Acts as child process to run event loop for analysis
+        input: criteria
+        output: nil
+        '''
         loop = asyncio.new_event_loop()
         loop.run_until_complete(self.start_analysis(criteria))
 

--- a/service/web_svc.py
+++ b/service/web_svc.py
@@ -6,6 +6,7 @@ import newspaper
 from nltk.stem import SnowballStemmer
 from html2text import html2text
 from bs4 import BeautifulSoup
+import asyncio
 
 
 class WebService:
@@ -22,6 +23,7 @@ class WebService:
         # Loop through pt one by one, matching its line with a forward-advancing pointer on the html
         counter = 0
         for pt in plaintext:
+            await asyncio.sleep(0.01)
             words = pt.split(' ')
             first_word = words[0]
             text_match_found = False
@@ -100,6 +102,7 @@ class WebService:
         lemmed = []
         stemmer = SnowballStemmer('english')
         for i in filtered_words:
+            await asyncio.sleep(0.001)
             lemmed.append(stemmer.stem(str(i)))
         return ' '.join(lemmed)
 
@@ -126,6 +129,7 @@ class WebService:
         if returned_format == 'html':
             print('[!] HTML support is being refactored. Currently data is being returned plaintext')
         r = requests.get(url)
+        await asyncio.sleep(0.01)
 
         b = newspaper.fulltext(r.text)
         return str(b).replace('\n', '<br>') if b else None


### PR DESCRIPTION
Places new reports to be analyzed in a queue, and adds the ability to manage the queue and the analysis of reports. Contains the capability to analyze multiple reports at the same time, however code currently analyzes one report at a time. Reports are analyzed in the background. The server returns immediately to the home page after submitting a report instead of waiting for the analysis of the report to finish. Switched to using only the asyncio library for queue and job management instead of process pools.