### PR TITLE
Added navigator layer download button to edit/analysis page

### DIFF
--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -133,7 +133,8 @@ class WebAPI:
             
         # Append techniques to enterprise layer
         if technique is not None:
-            enterprise_layer['techniques'].append(techniques)
+            for technique in techniques:
+                enterprise_layer['techniques'].append(technique)
             
         # Return the layer JSON in the response
         layer = json.dumps(enterprise_layer)

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -57,7 +57,7 @@ class WebAPI:
         :param request: The title of the report information
         :return: dictionary of report data
         """
-        report = await self.data_svc.get_report(request.match_info.get('file'))
+        report = await self.dao.get('reports', dict(title=request.match_info.get('file')))
         sentences = await self.data_svc.build_sentences(report[0]['uid'])
         attack_uids = await self.dao.get('attack_uids')
         original_html = await self.dao.get('original_html', dict(report_uid=report[0]['uid']))
@@ -71,7 +71,7 @@ class WebAPI:
         :return: the layer json
         """        
         # Get the report from the database
-        report = await self.data_svc.get_report(request.match_info.get('file'))
+        report = await self.dao.get('reports', dict(title=request.match_info.get('file')))
 
         # Create the layer name and description
         report_title = report[0]['title']
@@ -115,8 +115,8 @@ class WebAPI:
         :param request: The title of the report information
         :return: response status of function
         """
-        # Get the report 
-        report = await self.data_svc.get_report(request.match_info.get('file'))
+        # Get the report
+        report = await self.dao.get('reports', dict(title=request.match_info.get('file')))
         sentences = await self.data_svc.build_sentences(report[0]['uid'])
         attack_uids = await self.dao.get('attack_uids')
 

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -197,10 +197,6 @@ class DataService:
         techniques = await self.dao.get('attack_uids')
         return techniques
 
-    async def get_report(self, report_title):
-        report = await self.dao.get('reports', dict(title=report_title))
-        return report
-
     async def get_confirmed_techniques(self, report_id):
         techniques = []
         # Get all of the report sentences for the report

--- a/tram.py
+++ b/tram.py
@@ -58,7 +58,8 @@ async def init(host, port):
     app.router.add_route('GET', '/edit/{file}', website_handler.edit)
     app.router.add_route('GET', '/about', website_handler.about)
     app.router.add_route('*', '/rest', website_handler.rest_api)
-    app.router.add_route('GET', '/export/{file}', website_handler.pdf_export)
+    app.router.add_route('GET', '/export/pdf/{file}', website_handler.pdf_export)
+    app.router.add_route('GET', '/export/nav/{file}', website_handler.nav_export)
     app.router.add_static('/theme/', 'webapp/theme/')
 
     aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader('webapp/html'))

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -33,7 +33,16 @@
 
 <div class="row justify-content-center pb-3">
     <div class="col-md-auto">
-        <button onclick="$.getJSON('/export/{{file}}', (x) => {pdfMake.createPdf(x).download(x['info']['title']);})" class="btn btn-md btn-outline-secondary">Export PDF</button>
+        <button onclick="$.getJSON('/export/pdf/{{file}}', (x) => {pdfMake.createPdf(x).download(x['info']['title']);})" class="btn btn-md btn-outline-secondary">Export PDF</button>
+    </div>
+    <div class="col-md-auto">
+        <button class="btn btn-md btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export to Navigator</button>
+        <div class="dropdown-menu" id="dropdownMenu" aria-labelledby="dropdownMenuButton">
+            <h6 class="dropdown-header">Enterprise Layer</h6>
+            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {downloadLayer(x);})">download</a>
+            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {viewLayer(x);})">view</a>
+        </div>
+    </div>
     </div>
 </div>
 

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -36,11 +36,11 @@
         <button onclick="$.getJSON('/export/pdf/{{file}}', (x) => {pdfMake.createPdf(x).download(x['info']['title']);})" class="btn btn-md btn-outline-secondary">Export PDF</button>
     </div>
     <div class="col-md-auto">
-        <button class="btn btn-md btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export to Navigator</button>
+        <button class="btn btn-md btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export Navigator JSON</button>
         <div class="dropdown-menu" id="dropdownMenu" aria-labelledby="dropdownMenuButton">
             <h6 class="dropdown-header">Enterprise Layer</h6>
             <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {downloadLayer(x);})">download</a>
-            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {viewLayer(x);})">view</a>
+<!--            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {viewLayer(x);})">view</a>-->
         </div>
     </div>
     </div>

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -121,6 +121,31 @@ function updateConfirmedContext(data){
     })
 }
 
+function downloadLayer(data){
+  // Create the name of the JSON download file from the name of the report
+  var json = JSON.parse(data) 
+  var title = json['name'] //document.getElementById("title").value;
+  var filename = title + ".json";
+  // Encode data as a uri component
+  var dataStr = "text/json;charset=utf-8," + encodeURIComponent(data);
+  // Create temporary DOM element with attribute values needed to perform the download
+  var a = document.createElement('a');
+  a.href = 'data:' + dataStr;
+  a.download = filename;
+  a.innerHTML = 'download JSON';
+  // Add the temporary element to the DOM
+  var container = document.getElementById('dropdownMenu');
+  container.appendChild(a);
+  // Download the JSON document
+  a.click();
+  // Remove the temporary element from the DOM
+  a.remove();
+}
+
+function viewLayer(data){
+  console.info("viewLayer: " + data)
+}
+
 function divSentenceReload(){
     $('#sentenceContextSection').load(document.URL +  ' #sentenceContextSection');
 }


### PR DESCRIPTION
Added the 'Export to Navigator' drop-down button to the analysis/edit page that includes a 'download' and a 'view' option, similar to the drop-down button on the MITRE ATTACK website.
When 'download' is selected a new layer JSON object is generated in the layer format containing the confirmed techniques and this object is downloaded locally in a JSON file. The name of the JSON file downloaded is the name of the report being analyzed.
The view button to view the generated layer JSON object in the ATTACK Navigator has not been implemented, this is a feature that will be implemented.

To test, enter a report url and title, click 'Submit', when the report appears in the 'Needs Review' card, click 'Analyze' to bring up the analysis/edit page.
On the analysis/edit page, click the highlighted sentences to see the techniques found for that sentence, and click the 'Accept' button to confirm the technique.
After going through the report and confirming techniques found, click the 'Export to Navigator' drop-down button and click 'download' to generate the layer JSON object containing the confirmed techniques and download to a file.
