### PR TITLE
Feature/multiple report input

### DIFF
--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -55,8 +55,8 @@ class RestService:
 
     async def confirmed_sentences(self, criteria=None):
         tmp = []
-        techniques = await self.dao.get('true_positives', 
-                         dict(sentence_id=criteria['sentence_id'], element_tag=criteria['element_tag']))
+        techniques = await self.dao.get('true_positives',
+                                        dict(sentence_id=criteria['sentence_id'], element_tag=criteria['element_tag']))
         for tech in techniques:
             name = await self.dao.get('attack_uids', dict(uid=tech['uid']))
             tmp.append(name[0])
@@ -78,16 +78,15 @@ class RestService:
         return dict(status='inserted', last=last)
 
     async def insert_report(self, criteria=None):
-        #criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
+        # criteria['id'] = await self.dao.insert('reports', dict(title=criteria['title'], url=criteria['url'],
         #                                                       current_status="needs_review"))
         for i in range(len(criteria['title'])):
             temp_dict = dict(title=criteria['title'][i], url=criteria['url'][i],current_status="needs_review")
             await self.queue.put(temp_dict)
-        #criteria = dict(title=criteria['title'], url=criteria['url'],current_status="needs_review")
-        #await self.queue.put(criteria)
+        # criteria = dict(title=criteria['title'], url=criteria['url'],current_status="needs_review")
+        # await self.queue.put(criteria)
         asyncio.create_task(self.check_queue()) # check queue background task
         await asyncio.sleep(0.01)
-    
 
     async def check_queue(self):
         '''
@@ -96,27 +95,26 @@ class RestService:
         input: nil
         output: nil
         '''
-        for task in range(len(self.resources)): # check resources for finished tasks
-            if(self.resources[task].done()):
-                del self.resources[task] # delete finished tasks
+        for task in range(len(self.resources)):  # check resources for finished tasks
+            if self.resources[task].done():
+                del self.resources[task]  # delete finished tasks
 
         max_tasks = 1
-        while(self.queue.qsize() > 0): # while there are still tasks to do....
-            await asyncio.sleep(0.01) # check resources and execute tasks
-            if(len(self.resources) >= max_tasks): # if the resource pool is maxed out...
-                while(len(self.resources) >= max_tasks): # check resource pool until a task is finished
+        while self.queue.qsize() > 0:  # while there are still tasks to do....
+            await asyncio.sleep(0.01)  # check resources and execute tasks
+            if len(self.resources) >= max_tasks:  # if the resource pool is maxed out...
+                while len(self.resources) >= max_tasks:  # check resource pool until a task is finished
                     for task in range(len(self.resources)):
-                        if(self.resources[task].done()):
-                            del self.resources[task] # when task is finished, remove from resource pool
-                    await asyncio.sleep(1) # allow other tasks to run while waiting
-                criteria = await self.queue.get() # get next task off queue, and run it
+                        if self.resources[task].done():
+                            del self.resources[task]  # when task is finished, remove from resource pool
+                    await asyncio.sleep(1)  # allow other tasks to run while waiting
+                criteria = await self.queue.get()  # get next task off queue, and run it
                 task = asyncio.create_task(self.start_analysis(criteria))
                 self.resources.append(task)
             else:
                 criteria = await self.queue.get() # get next task off queue and run it
                 task = asyncio.create_task(self.start_analysis(criteria))
                 self.resources.append(task)
-
 
     async def start_analysis(self, criteria=None):
         tech_data = await self.dao.get('attack_uids')
@@ -179,7 +177,6 @@ class RestService:
         for element in original_html:
             html_element = dict(report_uid=report_id, text=element['text'], tag=element['tag'], found_status="false")
             await self.dao.insert('original_html', html_element)
-        
 
     async def missing_technique(self, criteria=None):
         attack_uid = await self.dao.get('attack_uids', dict(tid=criteria['tid']))

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -101,8 +101,8 @@ class RestService:
                 del self.resources[task] # delete finished tasks
 
         max_tasks = 1
-        while(self.queue.qsize() > 0):
-            await asyncio.sleep(0.01)
+        while(self.queue.qsize() > 0): # while there are still tasks to do....
+            await asyncio.sleep(0.01) # check resources and execute tasks
             if(len(self.resources) >= max_tasks): # if the resource pool is maxed out...
                 while(len(self.resources) >= max_tasks): # check resource pool until a task is finished
                     for task in range(len(self.resources)):

--- a/webapp/html/index.html
+++ b/webapp/html/index.html
@@ -17,11 +17,11 @@
                           <form>
                                 <div class="form-group">
                                     <label for="url">Insert URL</label>
-                                    <input type="url" class="form-control" id="url" placeholder="Enter URL">
+                                    <input type="url" class="form-control" id="url" placeholder="Enter URL(s) (comma seperated)">
                                 </div>
                                 <div class="form-group">
                                     <label for="title">Insert Title</label>
-                                    <input type="text" class="form-control" id="title" placeholder="Enter the article title">
+                                    <input type="text" class="form-control" id="title" placeholder="Enter the article title(s) (comma seperated)">
                                 </div>
                                 <button type="submit" onclick='submit_report()' class="btn btn-primary">Submit</button>
                             </form>

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -53,9 +53,13 @@ function set_status(set_status, file_name){
 }
 
 function submit_report(){
-    var url = document.getElementById("url").value;
-    var title = document.getElementById("title").value;
-    restRequest('POST', {'index':'insert_report', 'url':url, 'title':title}, show_info);
+    var url = document.getElementById("url").value.split(",");
+    var title = document.getElementById("title").value.split(",");
+    if(title.length != url.length){
+      alert("Number of urls and titles do not match, please insert same number of comma seperated iterms.");
+    }else{
+      restRequest('POST', {'index':'insert_report', 'url':url, 'title':title}, show_info);
+    }    
 }
 
 function show_dropdown() {

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -56,7 +56,7 @@ function submit_report(){
     var url = document.getElementById("url").value.split(",");
     var title = document.getElementById("title").value.split(",");
     if(title.length != url.length){
-      alert("Number of urls and titles do not match, please insert same number of comma seperated iterms.");
+      alert("Number of urls and titles do not match, please insert same number of comma seperated items.");
     }else{
       restRequest('POST', {'index':'insert_report', 'url':url, 'title':title}, show_info);
     }    


### PR DESCRIPTION
Able to process multiple reports at the same time through a single submit. Adjusted user interface to include comma separated prompt and some bounds checking. A user can now input multiple urls and multiple titles all at once by separating the urls and titles respectively with commas in the input bar. Fixed a bug with the check_queue function that wasn't allowing multiple report input.