### PR TITLE
Updated get_confirmed_techniques method to use a single inner join query

### DIFF
--- a/database/dao.py
+++ b/database/dao.py
@@ -25,3 +25,6 @@ class Dao:
 
     async def raw_query(self, query, one=False):
         return await self.db.raw_query(query, one)
+        
+    async def raw_select(self, query):
+        return await self.db.raw_select(query)


### PR DESCRIPTION

Updated get_confirmed_techniques method to use a single inner join query. Using a single inner join query will improve performance by only requiring a single call to the database.

Getting confirmed techniques from the database requires a select inner join query that joins the tables report_sentences, report_sentence_hits and true_positives.
Here is the actual query that is used:

```
SELECT report_sentences.uid,
       report_sentence_hits.attack_uid,
       report_sentence_hits.report_uid,
       report_sentence_hits.attack_tid,
       true_positives.true_positive
  FROM ((report_sentences
  INNER JOIN report_sentence_hits ON report_sentences.uid = report_sentence_hits.uid)
  INNER JOIN true_positives ON report_sentence_hits.uid = true_positives.sentence_id AND report_sentence_hits.attack_uid = true_positives.uid)
  WHERE report_sentence_hits.report_uid = {report_id}
UNION
SELECT report_sentences.uid,
       report_sentence_hits.attack_uid,
       report_sentence_hits.report_uid,
       report_sentence_hits.attack_tid,
       false_negatives.false_negative
  FROM ((report_sentences
  INNER JOIN report_sentence_hits ON report_sentences.uid = report_sentence_hits.uid)
  INNER JOIN false_negatives ON report_sentence_hits.uid = false_negatives.sentence_id AND report_sentence_hits.attack_uid = false_negatives.uid)
  WHERE report_sentence_hits.report_uid = {report_id}
```
  
The reason for this query is that the techniques included in the navigator layer json output must include both the sentence and the technique id (attack_tid)
The true_positives table contains the sentence_id, attack_uid and the sentence, the report_sentence_hits table contains the attack_tid and the report_id.
So all three tables are needed in the join to make sure all of the relevant information is retrieved from the database