### PR TITLE
Fixed add missing techniques to only add to confirmed techniques not techniques found

### DIFF
--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -176,6 +176,6 @@ $(window).resize(function() {
 function addMissingTechnique(){
     uid = $("#missingTechniqueSelect :selected").val();
     restRequest('POST', {'index':'missing_technique', 'sentence_id': sentence_id, 'attack_uid':uid, 'element_tag':element_clicked_tag}, show_info);
-    sentenceContext(sentence_id, element_clicked_tag, uid)
+    restRequest('POST', {'index':'confirmed_sentences', 'sentence_id': sentence_id, 'element_tag':element_clicked_tag}, updateConfirmedContext);
 }
 


### PR DESCRIPTION
When adding a missing technique to either a found sentence or a not found sentence, the technique is only added to the list of confirmed techniques but not added to the list of techniques found.