### PR TITLE
Update export

### DIFF
--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -123,7 +123,7 @@ class WebAPI:
 
         dd = dict()
         dd['content'] = []
-        dd['styles'] = dict()
+        dd['styles'] = {"color":"ffc107"}
 
         # Document MetaData Info
         # See https://pdfmake.github.io/docs/document-definition-object/document-medatadata/
@@ -132,11 +132,15 @@ class WebAPI:
         dd['info']['creator'] = report[0]['url']
 
         table = {"body": []}
-        table["body"].append(["ID", "Name", "Identified Sentence"])
+        table["body"].append(["ID", "Name", "Identified Sentence", "Confirmed"])
 
         # Add the text to the document
         for sentence in sentences:
-            dd['content'].append(sentence['text'])
+            if sentence['found_status'] == "true":
+                text = {"text": sentence['text'], "style": "color"}
+            else:
+                text = {"text": sentence['text']}
+            dd['content'].append(text)
             if sentence['hits']:
                 for hit in sentence['hits']:
                     table["body"].append([hit["attack_tid"], hit["name"], sentence['text']])

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -1,4 +1,7 @@
 from aiohttp_jinja2 import template, web
+from docx import Document
+from docx.enum.text import WD_COLOR_INDEX
+from io import BytesIO
 import nltk
 import json
 
@@ -111,13 +114,143 @@ class WebAPI:
         layer = json.dumps(enterprise_layer)
         return web.json_response(layer)
 
+    async def word_export(self, request):
+        """
+        Function to generate JSON object containing sentence and
+        sentence hit information needed to export report in Word format
+        :param request: The report information
+        :return: JSON response
+        """
+        # Get the report and report sentences data from the database
+        report = await self.dao.get('reports', dict(title=request.match_info.get('file')))
+        sentences = await self.data_svc.build_sentences_for_export(report[0]['uid'])
+        
+        # Create data structure for the JSON object to be returned
+        dd = {}
+        
+        # Add the default highlighting color style for found sentences
+        dd['styles'] = {"color":"ffc107"}
+
+        # Add the report info to the data object
+        dd['info'] = {}
+        dd['info']['title'] = report[0]['title']
+        dd['info']['creator'] = report[0]['url']
+        
+        # Create the table object containing the attack technique information
+        table = {"body": []}
+        table_header = {"id":"ID", "name":"Name", "sentence":"Identified Sentence", "confirmed":"Confirmed"}
+        table["body"].append(table_header)
+
+        # Add the sentence and sentence hits information to the data object
+        # and add the attack technique information to the table object
+        dd['sentences'] = []
+        # For every sentence returned get the sentence and sentence hits information
+        # and add it to the data object to be returned
+        for sentence in sentences:
+            # Get the sentence information
+            dd_sentence = {"text":sentence['text'], "found_status":sentence['found_status'], "hits": []}
+            if sentence['hits']:
+                # For every sentence hit, get the sentence hit information
+                for hit in sentence['hits']:
+                    # Get the sentence hit information and add it to the sentence object
+                    dd_hit = {"attack_tid":hit['attack_tid'], "name":hit['name'], "text":sentence['text'], "confirmed":hit['confirmed']}
+                    dd_sentence["hits"].append(dd_hit)
+                    # Get the attack technique information and add it to the table object
+                    table_row = {"id":hit['attack_tid'], "name":hit['name'], "sentence":sentence['text'], "confirmed":hit['confirmed']}
+                    table["body"].append(table_row)
+            # Add the sentence to the data object to be returned
+            dd['sentences'].append(dd_sentence)
+
+        # Add the table object to the date object to be returned
+        dd['table'] = {}
+        dd['table'] = table
+
+        # Return the data object as a JSON object
+        return web.json_response(dd)
+
+    async def export_to_word(self, request):
+        """
+        Function to generate the docx object containing sentence and
+        sentence hit information to export report in Word
+        :param request: The JSON report information
+        :return: A byte array response
+        """
+
+        # Get the JSON object containing the report information
+        data = dict(await request.json())
+        
+        # Create the docx Document object
+        document = Document()
+
+        # Add the title and heading to the document object
+        document.core_properties.title = data['info']['title']
+        document.add_heading(data['info']['title'], 1)
+        document.add_paragraph('')
+
+        # Get the sentences information from the data object
+        sentences = data['sentences']
+        # Add a new paragraph to the document object to contain the sentences
+        paragraph = document.add_paragraph()
+        
+        # Add each sentence to the paragraph in the document
+        for sentence in sentences:
+            # Get the found_status attribute of the sentence
+            found_status = sentence['found_status']
+            if found_status == 'true':
+                # if the sentence found status attribute is true then
+                # add the sentence with additional newlines and a '*' and
+                # highlighting to indicate that the sentence includes attack techniques
+                run = paragraph.add_run("\n* " + sentence['text'] + "\n")
+                run.font.highlight_color = WD_COLOR_INDEX.YELLOW
+            else:
+                # otherwise, just add the sentence to the paragraph
+                run = paragraph.add_run(sentence['text'])
+
+        # Add a table to the document object containing the attack techniques found
+        # Get the items in the table object from the data object
+        items = data['table']['body']
+        # Add a table to the document containing the attack technique found information
+        table = document.add_table(rows=0, cols=4, style='LightGrid')
+        # For each item in the table object, add a new row to the table
+        for item in items:
+            # Add d new row to the table
+            cells = table.add_row().cells
+            # If the item is the first item containing the table headers
+            # then add the table header row to the table
+            if item['id'] == 'ID':
+                run = cells[0].paragraphs[0].add_run(item['id'])
+                run.bold = True
+                run = cells[1].paragraphs[0].add_run(item['name'])
+                run.bold = True
+                run = cells[2].paragraphs[0].add_run(item['sentence'])
+                run.bold = True
+                run = cells[3].paragraphs[0].add_run(item['confirmed'])
+                run.bold = True
+            else:
+                # otherwise, add the item information to the row
+                cells[0].text = item['id']
+                cells[1].text = item['name']
+                cells[2].text = item['sentence']
+                cells[3].text = item['confirmed']
+        
+        # Save the document object to a byte stream
+        stream = BytesIO()
+        document.save(stream)
+        stream.seek(0)
+
+        # Read the document object from the byte stream to a byte array
+        b = bytearray(stream.read())
+        
+        # Return the byte array
+        return web.Response(body=b)
+        
     async def pdf_export(self, request):
         """
         Function to export report in PDF format
-        :param request: The title of the report information
-        :return: response status of function
+        :param request: The report information
+        :return: JSON response
         """
-        # Get the report
+        # Get the reports
         report = await self.dao.get('reports', dict(title=request.match_info.get('file')))
         sentences = await self.data_svc.build_sentences_for_export(report[0]['uid'])
 
@@ -143,7 +276,7 @@ class WebAPI:
             dd['content'].append(text)
             if sentence['hits']:
                 for hit in sentence['hits']:
-                    table["body"].append([hit["attack_tid"], hit["name"], sentence['text']])
+                    table["body"].append([hit['attack_tid'], hit['name'], sentence['text'], hit['confirmed']])
 
         # Append table to the end
         dd['content'].append({"table": table})

--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -119,8 +119,7 @@ class WebAPI:
         """
         # Get the report
         report = await self.dao.get('reports', dict(title=request.match_info.get('file')))
-        sentences = await self.data_svc.build_sentences(report[0]['uid'])
-        attack_uids = await self.dao.get('attack_uids')
+        sentences = await self.data_svc.build_sentences_for_export(report[0]['uid'])
 
         dd = dict()
         dd['content'] = []
@@ -140,13 +139,7 @@ class WebAPI:
             dd['content'].append(sentence['text'])
             if sentence['hits']:
                 for hit in sentence['hits']:
-                    # 'hits' object doesn't provide all the information we need, so we
-                    # do a makeshift join here to get that information from the attack_uid
-                    # list. This is ineffecient, and a way to improve this would be to perform
-                    # a join on the database side
-                    matching_attacks = [i for i in attack_uids if hit['attack_uid'] == i['uid']]
-                    for match in matching_attacks:
-                        table["body"].append([match["tid"], match["name"], sentence['text']])
+                    table["body"].append([hit["attack_tid"], hit["name"], sentence['text']])
 
         # Append table to the end
         dd['content'].append({"table": table})

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ tinysegmenter==0.3
 tldextract==2.2.2
 urllib3==1.25.7
 yarl==1.4.2
+python-docx==0.8.10

--- a/service/data_svc.py
+++ b/service/data_svc.py
@@ -193,6 +193,35 @@ class DataService:
                 sentence['confirmed'] = 'false'
         return sentences
 
+    async def build_sentences_for_export(self, report_id):
+        # Get the sentences for the report from the database
+        sentences = await self.dao.get('report_sentences', dict(report_uid=report_id))
+        # For each sentence, get the sentence hits and the confirmed status of the sentence hits
+        for sentence in sentences:
+            # The query to get the sentence hits from the database
+            sentence_id = sentence['uid']
+            hits_join_query = (
+                f"SELECT report_sentence_hits.uid, report_sentence_hits.attack_uid, attack_uids.name, report_sentence_hits.attack_tid, report_sentence_hits.report_uid "
+                f"FROM (report_sentence_hits INNER JOIN attack_uids ON report_sentence_hits.attack_uid = attack_uids.uid) "
+                f"WHERE report_sentence_hits.report_uid = {report_id} AND report_sentence_hits.uid = {sentence_id}")
+            # Get the sentence hits from the database
+            sentence['hits'] = await self.dao.raw_select(hits_join_query)
+            # For each sentence hit, get the confirmed status of the sentence hit
+            for hit in sentence['hits']:
+                # The query to get the confirmed status of the sentence hit
+                attack_uid = hit['attack_uid']
+                true_positives_query = (
+                    f"SELECT uid, sentence_id FROM true_positives WHERE uid = '{attack_uid}' AND sentence_id = {sentence_id} " 
+                    f"UNION "
+                    f"SELECT uid, sentence_id FROM false_negatives WHERE uid = '{attack_uid}' AND sentence_id = {sentence_id} ")
+                # Get the confirmed status of the sentence hit
+                if await self.dao.raw_select(true_positives_query):
+                    hit['confirmed'] = 'true'
+                else:
+                    hit['confirmed'] = 'false'
+        # Return the sentences
+        return sentences
+
     async def get_techniques(self):
         techniques = await self.dao.get('attack_uids')
         return techniques

--- a/tram.py
+++ b/tram.py
@@ -59,6 +59,8 @@ async def init(host, port):
     app.router.add_route('GET', '/about', website_handler.about)
     app.router.add_route('*', '/rest', website_handler.rest_api)
     app.router.add_route('GET', '/export/pdf/{file}', website_handler.pdf_export)
+    app.router.add_route('GET', '/export/word/{file}', website_handler.word_export)
+    app.router.add_route('*', '/export/word/doc', website_handler.export_to_word)
     app.router.add_route('GET', '/export/nav/{file}', website_handler.nav_export)
     app.router.add_static('/theme/', 'webapp/theme/')
 

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -36,6 +36,7 @@
         <button class="btn btn-md btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export to...</button>
         <div class="dropdown-menu" id="dropdownMenu" aria-labelledby="dropdownMenuButton">
             <a class="dropdown-item" onclick="$.getJSON('/export/pdf/{{file}}', (x) => {pdfMake.createPdf(x).download(x['info']['title']);})">Export to PDF</a>
+            <a class="dropdown-item" onclick="$.getJSON('/export/word/{{file}}', (x) => {exportToWord(x);})">Export to Word</a>
             <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {downloadJSON(x);})">Export to JSON</a>
 <!--            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {viewJSON(x);})">Export to Navigator</a>-->
         </div>

--- a/webapp/html/columns.html
+++ b/webapp/html/columns.html
@@ -31,16 +31,13 @@
 
 <h3 class="display-4 text-center">{{ file }}</h3>
 
-<div class="row justify-content-center pb-3">
-    <div class="col-md-auto">
-        <button onclick="$.getJSON('/export/pdf/{{file}}', (x) => {pdfMake.createPdf(x).download(x['info']['title']);})" class="btn btn-md btn-outline-secondary">Export PDF</button>
-    </div>
-    <div class="col-md-auto">
-        <button class="btn btn-md btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export Navigator JSON</button>
+<div class="row">
+    <div class="col-md-2 offset-md-8">
+        <button class="btn btn-md btn-outline-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Export to...</button>
         <div class="dropdown-menu" id="dropdownMenu" aria-labelledby="dropdownMenuButton">
-            <h6 class="dropdown-header">Enterprise Layer</h6>
-            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {downloadLayer(x);})">download</a>
-<!--            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {viewLayer(x);})">view</a>-->
+            <a class="dropdown-item" onclick="$.getJSON('/export/pdf/{{file}}', (x) => {pdfMake.createPdf(x).download(x['info']['title']);})">Export to PDF</a>
+            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {downloadJSON(x);})">Export to JSON</a>
+<!--            <a class="dropdown-item" onclick="$.getJSON('/export/nav/{{file}}', (x) => {viewJSON(x);})">Export to Navigator</a>-->
         </div>
     </div>
     </div>

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -143,7 +143,7 @@ function updateConfirmedContext(data){
     })
 }
 
-function downloadLayer(data){
+function downloadJSON(data){
   // Create the name of the JSON download file from the name of the report
   var json = JSON.parse(data) 
   var title = json['name'] //document.getElementById("title").value;
@@ -164,7 +164,7 @@ function downloadLayer(data){
   a.remove();
 }
 
-function viewLayer(data){
+function viewJSON(data){
   console.info("viewLayer: " + data)
 }
 

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -143,6 +143,46 @@ function updateConfirmedContext(data){
     })
 }
 
+function exportToWord(data){
+    // Create the file name of the Word document
+    var filename = data['info']['title'] + '.docx'
+    // A jquery ajax POST request is needed to call the python server method
+    // to build the Word document object and to receive the binary data for the download 
+    // This separate ajax POST request is required because the server method
+    // returns binary data not JSON data
+    $.ajax({
+        url: '/export/word/doc',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(data),
+        xhrFields: {responseType: 'blob'},
+        success:function(blob) { 
+            // Call the method that will download the binary data 
+            // to the Word document with the specified file name
+            downloadWord(filename, blob); 
+        },
+        error: function (xhr, ajaxOptions, thrownError) { console.log(thrownError); }
+    });
+}
+
+function downloadWord(filename, blob){
+    // Encode data as a uri component
+    var downloadUrl = window.URL.createObjectURL(blob);
+    // Create temporary DOM element with attribute values needed to perform the download
+    var a = document.createElement('a');
+    a.href = downloadUrl;
+    a.download = filename;
+    a.innerHTML = 'download Word';
+    // Add the temporary element to the DOM
+    var container = document.getElementById('dropdownMenu');
+    container.appendChild(a);
+    // Download the JSON document
+    a.click();
+    // Remove the temporary element from the DOM
+    a.remove();
+    URL.revokeObjectURL(downloadUrl);
+}
+
 function downloadJSON(data){
   // Create the name of the JSON download file from the name of the report
   var json = JSON.parse(data) 


### PR DESCRIPTION
Updated export capability to include:
- Merging the separate Export buttons into a single "Export to..." drop-down button.
- Updated the PDF export functionality to use a join query to get sentences from the database.
- Updated the PDF export functionality to highlight found sentences in the PDF document.
- Added Export to Word capability

Merging of the Export buttons into a single drop-down button required modification of the webapp/html/columns.html file.

Updating the PDF export functionality to use a join query required modification to the "PDF_export" method in the handlers/web_api.py file and creating a new method "build_sentences_for_export" in the service/data_svc.py file. The "build_sentences_for_export" method uses two join queries to retrieve the sentence and sentence hits data from the database and return the data to the "pdf_export" method.

Updating the PDF export functionality to highlight found sentences in the PDF document generated required modification to the "pdf_export" method in the handlers/web_api.py file to add a style attribute to the sentence object. This style attribute was interpreted by the PDF make library to bold the sentence rather than highlight the sentence in the PDF document.

Adding the Export to Word capability required the following steps:
- Added the "Export to Word" option to the "Export to..." drop-down button
- when the "Export to Word" option is selected, the jquery getJSON method is called to make a GET request to "/export/word/{file}", 
- this request is sent to the "word_export" method in the handlers/web_api.py file to query the database and create the JSON object containing the sentence data.
- The JSON object is returned in the response and passed to the "exportToWord" method in the webapp/theme/scripts/basic.js file
- The "exportToWord" method makes a jquery ajax POST request to "/export/word/doc"
Note: This separate ajax POST request is required because the server method returns binary data not JSON data
- this request is sent to the "export_to_word" method in the handlers/web_api.py file to build the docx Document object from the sentence data
- The "export_to_word" method returns the Document object as a binary byte array in the response
- The binary byte array returned to the "exportToWord" is passed to the "downloadWord" to be downloaded by the browser as a Word document
Note: The two separate jquery ajax requests should be combined into a single request, but I did not want to dramatically change the way the application works, i.e. one method to get the JSON object data and another to generate the output, especially since the api is currently being revised.

To test, enter a report url and title, click "Submit", when the report appears in the "Needs Review" card, click "Analyze" to bring up the analysis/edit page.
On the analysis/edit page, click the highlighted sentences to see the techniques found for that sentence, and click the "Accept" button to confirm the technique.
After going through the report and confirming techniques found, click the "Export to.." drop-down button and select "Export to PDF" or "Export to Word" to generate and download the document