### PR TITLE
Fixed deletion bug

### DIFF
--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -28,6 +28,9 @@ class RestService:
         return dict(status="Report status updated to " + criteria['set_status'])
 
     async def delete_report(self, criteria=None):
+        sentences = await self.dao.get('report_sentences', dict(report_uid=criteria['report_id']))
+        for sentence in sentences:
+            await self.remove_sentences(dict(sentence_id=sentence['uid']))
         await self.dao.delete('reports', dict(uid=criteria['report_id']))
         await self.dao.delete('report_sentences', dict(report_uid=criteria['report_id']))
         await self.dao.delete('report_sentence_hits', dict(report_uid=criteria['report_id']))
@@ -40,12 +43,12 @@ class RestService:
             false_positives = await self.dao.get('false_positives', dict(sentence_id=criteria['sentence_id']))
             false_negatives = await self.dao.get('false_negatives', dict(sentence_id=criteria['sentence_id']))
         if not true_positives and not false_positives and not false_negatives:
-            return dict(status="There is no entry for sentence id " + criteria['sentence_id'])
+            return dict(status="There is no entry for sentence id " + str(criteria['sentence_id']))
         else:
             await self.dao.delete('true_positives', dict(sentence_id=criteria['sentence_id']))
             await self.dao.delete('false_positives', dict(sentence_id=criteria['sentence_id']))
             await self.dao.delete('false_negatives', dict(sentence_id=criteria['sentence_id']))
-            return dict(status='Successfully moved sentence ' + criteria['sentence_id'])
+            return dict(status='Successfully moved sentence ' + str(criteria['sentence_id']))
 
     async def sentence_context(self, criteria=None):
         if criteria['element_tag']=='img':


### PR DESCRIPTION
Not able to replicate this bug. When pressing the delete button on the card for a report, the report is removed from the UI and from the database.

However while the report entries were removed from the database in the tables reports, report_sentences and report_sentence_hits, the corresponding sentences were not removed from the true_positives and false_negatives tables.

Updated the delete_report method in rest_svc.py to remove the corresponding sentences from the true_positive and false_negatives tables.