### PR TITLE
Automatic downloading of Punkt Tokenizer Models

### DIFF
--- a/handlers/web_api.py
+++ b/handlers/web_api.py
@@ -13,7 +13,12 @@ class WebAPI:
         self.ml_svc = services['ml_svc']
         self.reg_svc = services['reg_svc']
         self.rest_svc = services['rest_svc']
-        self.tokenizer_sen = nltk.data.load('tokenizers/punkt/english.pickle')
+        try:
+            self.tokenizer_sen = nltk.data.load('tokenizers/punkt/english.pickle')
+        except LookupError:
+            logging.info('Downloading Punkt Tokenizer Models')
+            nltk.download('punkt')
+            self.tokenizer_sen = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
 
     @template('about.html')
     async def about(self, request):


### PR DESCRIPTION
On a fresh install, nltk Punkt Tokenizer Models is not install:

```console

$ git clone https://github.com/mitre-attack/tram.git tram_git
$ python3 -m venv tram_venv
$ source tram_venv/bin/activate
$ cd tram_git/
$ pip install --upgrade pip wheel setuptools
$ pip install -r requirements.txt
$ python tram.py 
INFO:root:Welcome to TRAM
DEBUG:asyncio:Using selector: EpollSelector
Traceback (most recent call last):
  File "tram.py", line 117, in <module>
    website_handler = WebAPI(services=services)
  File "/home/yo/Documents/DFIR/TRAM/tram_git/handlers/web_api.py", line 16, in __init__
    self.tokenizer_sen = nltk.data.load('tokenizers/punkt/english.pickle')
  File "/home/yo/Documents/DFIR/TRAM/tram_venv/lib/python3.7/site-packages/nltk/data.py", line 868, in load
    opened_resource = _open(resource_url)
  File "/home/yo/Documents/DFIR/TRAM/tram_venv/lib/python3.7/site-packages/nltk/data.py", line 993, in _open
    return find(path_, path + ['']).open()
  File "/home/yo/Documents/DFIR/TRAM/tram_venv/lib/python3.7/site-packages/nltk/data.py", line 701, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource punkt not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt/PY3/english.pickle

  Searched in:
    - '/home/yo/nltk_data'
    - '/home/yo/Documents/DFIR/TRAM/tram_venv/nltk_data'
    - '/home/yo/Documents/DFIR/TRAM/tram_venv/share/nltk_data'
    - '/home/yo/Documents/DFIR/TRAM/tram_venv/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
    - ''
```

With this PR:
```console

$ python tram.py  
INFO:root:Welcome to TRAM
DEBUG:asyncio:Using selector: EpollSelector
INFO:root:Downloading Punkt Tokenizer Models
[nltk_data] Downloading package punkt to /home/yo/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
INFO:root:Downloading ATT&CK data from STIX/TAXII...
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): cti-taxii.mitre.org:443
DEBUG:urllib3.connectionpool:https://cti-taxii.mitre.org:443 "GET /stix/collections/95ecc380-afe9-11e4-9b6c-751b66dd541e/ HTTP/1.1" 200 249
DEBUG:urllib3.connectionpool:https://cti-taxii.mitre.org:443 "GET /stix/collections/95ecc380-afe9-11e4-9b6c-751b66dd541e/objects/?match%5Btype%5D=attack-pattern HTTP/1.1" 200 994676
DEBUG:urllib3.connectionpool:https://cti-taxii.mitre.org:443 "GET /stix/collections/95ecc380-afe9-11e4-9b6c-751b66dd541e/objects/?match%5Btype%5D=intrusion-set HTTP/1.1" 200 198576
DEBUG:urllib3.connectionpool:https://cti-taxii.mitre.org:443 "GET /stix/collections/95ecc380-afe9-11e4-9b6c-751b66dd541e/objects/?match%5Btype%5D=malware HTTP/1.1" 200 429055
DEBUG:urllib3.connectionpool:https://cti-taxii.mitre.org:443 "GET /stix/collections/95ecc380-afe9-11e4-9b6c-751b66dd541e/objects/?match%5Btype%5D=tool HTTP/1.1" 200 68856
DEBUG:urllib3.connectionpool:https://cti-taxii.mitre.org:443 "GET /stix/collections/95ecc380-afe9-11e4-9b6c-751b66dd541e/objects/?match%5Btype%5D=relationship HTTP/1.1" 200 5632512
INFO:root:Finished...now creating the database.
INFO:root:[!] DB Item Count: 630
INFO:root:[*] Found punkt
WARNING:root:Could not find the stopwords pack, downloading now
[nltk_data] Downloading package stopwords to /home/yo/nltk_data...
[nltk_data]   Unzipping corpora/stopwords.zip.
INFO:root:server starting: 0.0.0.0:9999

```