### PR TITLE
Report stuck in queue

### DIFF
--- a/exception/exceptions.py
+++ b/exception/exceptions.py
@@ -1,0 +1,5 @@
+class ImportReportError(Exception):
+    """ exception when a report cannot be imported """
+    def __init__(self, msg, report_id):
+        self.msg = msg
+        self.report_id = report_id

--- a/exception/exceptions.py
+++ b/exception/exceptions.py
@@ -1,5 +1,4 @@
 class ImportReportError(Exception):
     """ exception when a report cannot be imported """
-    def __init__(self, msg, report_id):
-        self.msg = msg
-        self.report_id = report_id
+    def __init__(self, message):
+        self.message = message

--- a/service/rest_svc.py
+++ b/service/rest_svc.py
@@ -213,17 +213,20 @@ class RestService:
             for element in original_html:
                 html_element = dict(report_uid=report_id, text=element['text'], tag=element['tag'], found_status="false")
                 await self.dao.insert('original_html', html_element)    
-            
+        
+        # if an exception is raised during the analysis of the report then
+        # output an error message to the console, delete the report from the database,
+        # and raise an ImportReportError
         except requests.exceptions.TooManyRedirects:
-            logging.error("Error: TooManyRedirects thrown trying to get report " + criteria['title'])
+            logging.error("Error: TooManyRedirects Exception trying to get report: " + criteria['title'])
             await self.dao.delete('reports', dict(uid=criteria['id']))
             raise ImportReportError("Unable to process report " + criteria['title'])
         except requests.exceptions.RequestException:
-            logging.error("Error: RequestException trying to get report " + criteria['title'])
+            logging.error("Error: RequestException trying to get report: " + criteria['title'])
             await self.dao.delete('reports', dict(uid=criteria['id']))
             raise ImportReportError("Unable to process report " + criteria['title'])
         except Exception:
-            logging.error("Error: Exception thrown processing report " + criteria['title'])
+            logging.error("Error: Exception thrown processing report: " + criteria['title'])
             await self.dao.delete('reports', dict(uid=criteria['id']))
             raise ImportReportError("Unable to process report " + criteria['title'])
 

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -58,7 +58,7 @@ function submit_report(){
     if(title.length != url.length){
       alert("Number of urls and titles do not match, please insert same number of comma seperated items.");
     }else{
-      restRequest('POST', {'index':'insert_report', 'url':url, 'title':title}, show_info);
+      restRequest('POST', {'index':'insert_report', 'url':url, 'title':title}, upload_success);
     }    
 }
 
@@ -72,13 +72,19 @@ function upload_file(){
     reader.readAsText(file, "UTF-8");
     reader.onload = function(evt){
       console.log(evt.target.result)
-      restRequest('POST', {'index':'insert_csv','file':evt.target.result},show_info);
+      restRequest('POST', {'index':'insert_csv','file':evt.target.result},upload_success);
     }
     reader.onerror = function(evt){
       alert("Error reading file");
     }
   }
 }
+
+function upload_success(data) {
+    if (data.status == "error") {
+        alert("Error: " + data.msg);
+    }
+} 
 
 function show_dropdown() {
   document.getElementById("myDropdown").classList.toggle("show");

--- a/webapp/theme/scripts/basics.js
+++ b/webapp/theme/scripts/basics.js
@@ -81,8 +81,9 @@ function upload_file(){
 }
 
 function upload_success(data) {
-    if (data.status == "error") {
-        alert("Error: " + data.msg);
+    var json = JSON.parse(data) 
+    if (json.status == "error") {
+        alert("Error: " + json.msg);
     }
 } 
 


### PR DESCRIPTION
Added exception handling to the service/rest_svc.py module that when an error occurs during the analysis of a report, an error message is output to the console, the report is deleted from the database to remove the report form the queue, and the exception ImportReportError is raised.
The exception is currently not output to the user on the UI as the ImportReportError is not propagated up through the stack due to the methods being asyncio tasks.
An output indicating the error to the user on the UI should be a new issue/bug.